### PR TITLE
fix: auth forms wrapper

### DIFF
--- a/client/src/containers/Routing/index.jsx
+++ b/client/src/containers/Routing/index.jsx
@@ -24,12 +24,12 @@ class Routing extends React.Component {
   }
 
   render() {
-    const { loading } = this.props;
+    const { loading, isAuthorized } = this.props;
 
     return loading ? (
       <Spinner />
     ) : (
-      <section className="main-wrapper">
+      <section className={'main-wrapper' + (!isAuthorized ? ' auth-wrapper' : '')}>
         <div className="content">
           <Header />
           <Switch>
@@ -62,11 +62,13 @@ class Routing extends React.Component {
 
 Routing.propTypes = {
   loading: PropTypes.bool.isRequired,
+  isAuthorized: PropTypes.bool.isRequired,
   fetchCurrentUser: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ profile: { loading } }) => ({
-  loading
+const mapStateToProps = ({ profile: { loading, isAuthorized } }) => ({
+  loading,
+  isAuthorized
 });
 
 const mapDispatchToProps = {

--- a/client/src/containers/Routing/styles.module.scss
+++ b/client/src/containers/Routing/styles.module.scss
@@ -1,7 +1,10 @@
 :global(.main-wrapper) {
+  min-height: 100%;
   margin: 0;
   padding: 0;
-  min-height: 100%;
+  &:global(.auth-wrapper) {
+    height: 100%;
+  }
   > :global(.content) {
     height: 100%;
     grid-row-start: 1;


### PR DESCRIPTION
If the user is not authorized, we don't show him the footer. If authorized, we show the footer and it must be sticky. If you have a better idea - do it